### PR TITLE
Fix the "%" indicator character in services (deprecated since Symfoy 3.1)

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -13,7 +13,7 @@ services:
     metaclass_auth_guard.connection_login:
         class: Doctrine\DBAL\Connection
         factory: ["@doctrine", getConnection]
-        arguments: [%metaclass_auth_guard.db_connection.name%]
+        arguments: ["%metaclass_auth_guard.db_connection.name%"]
 
     metaclass_auth_guard.gateway:
         class: %metaclass_auth_guard.gateway.class%
@@ -24,8 +24,8 @@ services:
         arguments: ["@metaclass_auth_guard.gateway"]
 
     metaclass_auth_guard.tresholds_governor:
-        class: %metaclass_auth_guard.tresholds_governor.class%
-        arguments: [%metaclass_auth_guard.tresholds_governor_params%, "@metaclass_auth_guard.manager"]
+        class: "%metaclass_auth_guard.tresholds_governor.class%"
+        arguments: ["%metaclass_auth_guard.tresholds_governor_params%", "@metaclass_auth_guard.manager"]
 
     metaclass_auth_guard.statistics_manager:
          alias: metaclass_auth_guard.manager


### PR DESCRIPTION
Fixing the % indicator in the services definition.

This is deprecated since Symfony 3.1 and won't work for Symfony 4.0+.

@metaclass-nl @stof 