### PR TITLE
Do not clear session data if there is no user token in session

### DIFF
--- a/Service/UsernamePasswordFormAuthenticationGuard.php
+++ b/Service/UsernamePasswordFormAuthenticationGuard.php
@@ -172,10 +172,13 @@ class UsernamePasswordFormAuthenticationGuard extends AbstractAuthenticationList
                     //when the user goes to the login page without logging out or on reauthentication because of
                     //an InsufficientAuthenticationException there may still be a UsernamePasswordToken
                     $oldToken = $this->myTokenStorage->getToken();
-                    $oldUserName = $oldToken instanceof UsernamePasswordToken ? $oldToken->getUserName() : '';
-                    if ($newToken instanceof UsernamePasswordToken && trim($newToken->getUserName()) != trim($oldUserName)) {
-                        //user has changed without logout, clear session so that the data of the old user can not leak to the new user
-                        $request->getSession()->clear();
+                    if ($oldToken !== null) {
+                        $oldUserName = $oldToken instanceof UsernamePasswordToken ? $oldToken->getUserName() : '';
+
+                        if ($newToken instanceof UsernamePasswordToken && trim($newToken->getUserName()) != trim($oldUserName)) {
+                            //user has changed without logout, clear session so that the data of the old user can not leak to the new user
+                            $request->getSession()->clear();
+                        }
                     }
 
                     return $newToken;


### PR DESCRIPTION
This piece of code is breaking Symfony's default behaviour of redirecting the user back to the page he was initially trying to access. I'm not sure how the native Symfony listener is solving this issue, but my suggestion would be to not clear all session data, especially if there is no trace of a previous user login (token).

Please let me know what you think of the proposed fix.

Cheers,

Robbert